### PR TITLE
test: Election created_at on /elections

### DIFF
--- a/spec/features/elections/index_spec.rb
+++ b/spec/features/elections/index_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe "elections index page", type: :feature do
         expect(page).to have_content(council_d1.name)
       end
 
-      it "I see that records are ordered by most recently created first" do
+      # User Story 6
+      it "I see that Elections are ordered by most recently created first" do
         council_d1 = Election.create!(name: "City Council: District 1", priority: 4, year: 2023, runoff: false)
         sleep 0.5
         auditor = Election.create!(name: "Auditor", priority: 2, year: 2023, runoff: false)
@@ -38,7 +39,16 @@ RSpec.describe "elections index page", type: :feature do
         expect(auditor.name).to appear_before(council_d1.name)
       end
 
-      it "I see that "
+      # User Story 6
+      it "I see when an Election was created next to the Election" do
+        mayor = Election.create!(name: "Denver Mayor", priority: 1, year: 2023, runoff: false)
+
+        visit "/elections"
+
+        save_and_open_page
+
+        expect(page).to have_content(mayor.created_at)
+      end
     end
   end
 end


### PR DESCRIPTION
Add test for User Story 6 for showing the time an election was created at to the /elections index page that I should have included earlier